### PR TITLE
Update DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ Description: Extend 'shinydashboard' with 'AdminLTE2' components.
 License: GPL-2
 Imports: shiny, shinydashboard, htmltools
 Suggests:
-    styler,
+    styler (>= 1.0.2),
     shinyAce,
     shinyWidgets,
     shinyjqui,


### PR DESCRIPTION
styler `v1.0.2` is now available on CRAN and I suggest to add a minimal version dependency to shinydashboardPlus to import this version. Most notable fixes (including critical fixes like implicit dependency removal) were already present in a prior release `v1.0.1`, but currently, shinydashboardPlus does not specify a minimal version for styler. You can find the changelog [here](http://styler.r-lib.org/news/index.html).